### PR TITLE
Handle errors in tests to make gosec happy.

### DIFF
--- a/storers/postgres/test_helpers.go
+++ b/storers/postgres/test_helpers.go
@@ -90,12 +90,18 @@ func (f *Factory) TeardownStorers() error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	for table, conn := range f.databases {
-		conn.Close()
-		_, err := f.db.Exec("DROP DATABASE " + table + ";")
+		err := conn.Close()
+		if err != nil {
+			return err
+		}
+		_, err = f.db.Exec("DROP DATABASE " + table + ";")
 		if err != nil {
 			return err
 		}
 	}
-	f.db.Close()
+	err := f.db.Close()
+	if err != nil {
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
## Description

gosec was failing because we weren't handling our error returns from closing database connections when cleaning up tests. This adds error handling to those connection closures.
