### PR TITLE
Upgrade Grants to be able to replace refresh tokens.

### DIFF
--- a/grant.go
+++ b/grant.go
@@ -11,6 +11,9 @@ var (
 	// ErrGrantAlreadyUsed is returned when a grant is being used, but has already been used. This
 	// usually indicates a replay attack.
 	ErrGrantAlreadyUsed = errors.New("grant already used, cannot be exchanged again")
+	// ErrGrantRevoked is returned when a grant is being used, but has been
+	// revoked. This usually indicates a leaked credential being exploited.
+	ErrGrantRevoked = errors.New("grant was revoked, cannot be exchanged")
 	// ErrGrantNotFound is returned when a grant is being used or referenced, but does not exist in
 	// the Storer being used. This usually indicates an invalid Grant is being presented.
 	ErrGrantNotFound = errors.New("grant not found")
@@ -24,18 +27,20 @@ var (
 
 // Grant represents a user's authorization for the use of their account to some client.
 type Grant struct {
-	ID         string    // a unique ID
-	SourceType string    // the type of the source used to identify the user
-	SourceID   string    // the ID of the source used to identify the user; should be unique across grants
-	CreatedAt  time.Time // when the authorization was granted
-	UsedAt     time.Time // when the authorization was exchanged for a session
-	Scopes     []string  // the scopes of access the user granted
-	AccountID  string    // the ID of the account that was used to grant access
-	ProfileID  string    // the unique ID representing the user
-	ClientID   string    // the client access was granted to
-	CreateIP   string    // the IP the user granted access from
-	UseIP      string    // the IP the access was exchanged for a session from
-	Used       bool      // whether the access has been exchanged for a session or not
+	ID          string    // a unique ID
+	SourceType  string    // the type of the source used to identify the user
+	SourceID    string    // the ID of the source used to identify the user; should be unique across grants
+	AncestorIDs []string  // the IDs of any Grants that led to the creation of this grant, e.g. through refresh
+	CreatedAt   time.Time // when the authorization was granted
+	UsedAt      time.Time // when the authorization was exchanged for a session
+	Scopes      []string  // the scopes of access the user granted
+	AccountID   string    // the ID of the account that was used to grant access
+	ProfileID   string    // the unique ID representing the user
+	ClientID    string    // the client access was granted to
+	CreateIP    string    // the IP the user granted access from
+	UseIP       string    // the IP the access was exchanged for a session from
+	Used        bool      // whether the access has been exchanged for a session or not
+	Revoked     bool      // whether the grant has been manually revoked or not
 }
 
 // GrantUse represents the exchange of a Grant for a session.

--- a/storer.go
+++ b/storer.go
@@ -8,6 +8,7 @@ import (
 type Storer interface {
 	CreateGrant(ctx context.Context, g Grant) error
 	ExchangeGrant(ctx context.Context, g GrantUse) (Grant, error)
+	RevokeGrant(ctx context.Context, id string) (Grant, error)
 	GetGrant(ctx context.Context, id string) (Grant, error)
 	GetGrantBySource(ctx context.Context, sourceType, sourceID string) (Grant, error)
 }

--- a/storer_test.go
+++ b/storer_test.go
@@ -86,15 +86,16 @@ func TestCreateAndExchangeGrant(t *testing.T) {
 
 	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
 		grant := grants.Grant{
-			ID:         uuidOrFail(t),
-			SourceType: "manual",
-			SourceID:   "TestCreateAndExchangeGrant",
-			UsedAt:     time.Now().Add(time.Hour).Round(time.Millisecond),
-			Scopes:     pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
-			ProfileID:  "tester",
-			AccountID:  "test123",
-			ClientID:   "testrunner",
-			CreateIP:   "192.168.1.2",
+			ID:          uuidOrFail(t),
+			SourceType:  "manual",
+			SourceID:    "TestCreateAndExchangeGrant",
+			AncestorIDs: pqarrays.StringArray{uuidOrFail(t), uuidOrFail(t)},
+			UsedAt:      time.Now().Add(time.Hour).Round(time.Millisecond),
+			Scopes:      pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
+			ProfileID:   "tester",
+			AccountID:   "test123",
+			ClientID:    "testrunner",
+			CreateIP:    "192.168.1.2",
 		}
 		err := storer.CreateGrant(ctx, grant)
 		if err != nil {
@@ -117,6 +118,38 @@ func TestCreateAndExchangeGrant(t *testing.T) {
 }
 
 func TestCreateAndGetGrant(t *testing.T) {
+	t.Parallel()
+
+	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
+		grant := grants.Grant{
+			ID:          uuidOrFail(t),
+			SourceType:  "manual",
+			SourceID:    "TestCreateAndExchangeGrant",
+			AncestorIDs: pqarrays.StringArray{uuidOrFail(t), uuidOrFail(t)},
+			UsedAt:      time.Now().Add(time.Hour).Round(time.Millisecond),
+			Scopes:      pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
+			ProfileID:   "tester",
+			AccountID:   "test123",
+			ClientID:    "testrunner",
+			CreateIP:    "192.168.1.2",
+		}
+		err := storer.CreateGrant(ctx, grant)
+		if err != nil {
+			t.Errorf("Unexpected error creating grant in %T: %+v\n", storer, err)
+		}
+
+		resp, err := storer.GetGrant(ctx, grant.ID)
+		if err != nil {
+			t.Errorf("Unexpected error retrieving grant from %T: %+v\n", storer, err)
+		}
+		expectation := grant
+		if diff := cmp.Diff(expectation, resp); diff != "" {
+			t.Errorf("Unexpected diff (-wanted, +got): %s", diff)
+		}
+	})
+}
+
+func TestCreateAndGetRootGrant(t *testing.T) {
 	t.Parallel()
 
 	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
@@ -152,15 +185,16 @@ func TestCreateAndGetGrantBySource(t *testing.T) {
 
 	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
 		grant := grants.Grant{
-			ID:         uuidOrFail(t),
-			SourceType: "manual",
-			SourceID:   "TestCreateAndGetGrantBySource",
-			UsedAt:     time.Now().Add(time.Hour).Round(time.Millisecond),
-			Scopes:     pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
-			ProfileID:  "tester",
-			AccountID:  "test123",
-			ClientID:   "testrunner",
-			CreateIP:   "192.168.1.2",
+			ID:          uuidOrFail(t),
+			SourceType:  "manual",
+			SourceID:    "TestCreateAndGetGrantBySource",
+			AncestorIDs: pqarrays.StringArray{uuidOrFail(t), uuidOrFail(t)},
+			UsedAt:      time.Now().Add(time.Hour).Round(time.Millisecond),
+			Scopes:      pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
+			ProfileID:   "tester",
+			AccountID:   "test123",
+			ClientID:    "testrunner",
+			CreateIP:    "192.168.1.2",
 		}
 		err := storer.CreateGrant(ctx, grant)
 		if err != nil {
@@ -183,15 +217,16 @@ func TestCreateAndExchangeUsedGrant(t *testing.T) {
 
 	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
 		grant := grants.Grant{
-			ID:         uuidOrFail(t),
-			SourceType: "manual",
-			SourceID:   "TestCreateAndExchangeUsedGrant",
-			UsedAt:     time.Now().Add(time.Hour).Round(time.Millisecond),
-			Scopes:     pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
-			ProfileID:  "tester",
-			AccountID:  "test123",
-			ClientID:   "testrunner",
-			CreateIP:   "192.168.1.2",
+			ID:          uuidOrFail(t),
+			SourceType:  "manual",
+			SourceID:    "TestCreateAndExchangeUsedGrant",
+			AncestorIDs: pqarrays.StringArray{uuidOrFail(t), uuidOrFail(t)},
+			UsedAt:      time.Now().Add(time.Hour).Round(time.Millisecond),
+			Scopes:      pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
+			ProfileID:   "tester",
+			AccountID:   "test123",
+			ClientID:    "testrunner",
+			CreateIP:    "192.168.1.2",
 		}
 		err := storer.CreateGrant(ctx, grant)
 		if err != nil {
@@ -205,6 +240,39 @@ func TestCreateAndExchangeUsedGrant(t *testing.T) {
 
 		_, err = storer.ExchangeGrant(ctx, grants.GrantUse{Grant: grant.ID, IP: "5.6.7.8", Time: time.Now().Round(time.Millisecond)})
 		if !errors.Is(err, grants.ErrGrantAlreadyUsed) {
+			t.Errorf("Expected error to be %v, %T returned %v\n", grants.ErrGrantAlreadyUsed, storer, err)
+		}
+	})
+}
+
+func TestCreateAndExchangeRevokedGrant(t *testing.T) {
+	t.Parallel()
+
+	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
+		grant := grants.Grant{
+			ID:          uuidOrFail(t),
+			SourceType:  "manual",
+			SourceID:    "TestCreateAndExchangeRevokedGrant",
+			AncestorIDs: pqarrays.StringArray{uuidOrFail(t), uuidOrFail(t)},
+			UsedAt:      time.Now().Add(time.Hour).Round(time.Millisecond),
+			Scopes:      pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
+			ProfileID:   "tester",
+			AccountID:   "test123",
+			ClientID:    "testrunner",
+			CreateIP:    "192.168.1.2",
+		}
+		err := storer.CreateGrant(ctx, grant)
+		if err != nil {
+			t.Errorf("Unexpected error creating grant in %T: %+v\n", storer, err)
+		}
+
+		_, err = storer.RevokeGrant(ctx, grant.ID)
+		if err != nil {
+			t.Errorf("Unexpected error exchanging grant in %T: %+v\n", storer, err)
+		}
+
+		_, err = storer.ExchangeGrant(ctx, grants.GrantUse{Grant: grant.ID, IP: "5.6.7.8", Time: time.Now().Round(time.Millisecond)})
+		if !errors.Is(err, grants.ErrGrantRevoked) {
 			t.Errorf("Expected error to be %v, %T returned %v\n", grants.ErrGrantAlreadyUsed, storer, err)
 		}
 	})
@@ -252,15 +320,16 @@ func TestCreateDuplicateGrant(t *testing.T) {
 
 	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
 		grant := grants.Grant{
-			ID:         uuidOrFail(t),
-			SourceType: "manual",
-			SourceID:   "TestCreateDuplicateGrant",
-			UsedAt:     time.Now().Add(time.Hour).Round(time.Millisecond),
-			Scopes:     pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
-			ProfileID:  "tester",
-			AccountID:  "test123",
-			ClientID:   "testrunner",
-			CreateIP:   "192.168.1.2",
+			ID:          uuidOrFail(t),
+			SourceType:  "manual",
+			SourceID:    "TestCreateDuplicateGrant",
+			AncestorIDs: pqarrays.StringArray{uuidOrFail(t), uuidOrFail(t)},
+			UsedAt:      time.Now().Add(time.Hour).Round(time.Millisecond),
+			Scopes:      pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
+			ProfileID:   "tester",
+			AccountID:   "test123",
+			ClientID:    "testrunner",
+			CreateIP:    "192.168.1.2",
 		}
 		err := storer.CreateGrant(ctx, grant)
 		if err != nil {
@@ -281,15 +350,16 @@ func TestCreateDuplicateSourceGrant(t *testing.T) {
 
 	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
 		grant := grants.Grant{
-			ID:         uuidOrFail(t),
-			SourceType: "manual",
-			SourceID:   "TestCreateDuplicateSourceGrant",
-			UsedAt:     time.Now().Add(time.Hour).Round(time.Millisecond),
-			Scopes:     pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
-			ProfileID:  "tester",
-			AccountID:  "test123",
-			ClientID:   "testrunner",
-			CreateIP:   "192.168.1.2",
+			ID:          uuidOrFail(t),
+			SourceType:  "manual",
+			SourceID:    "TestCreateDuplicateSourceGrant",
+			AncestorIDs: pqarrays.StringArray{uuidOrFail(t), uuidOrFail(t)},
+			UsedAt:      time.Now().Add(time.Hour).Round(time.Millisecond),
+			Scopes:      pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
+			ProfileID:   "tester",
+			AccountID:   "test123",
+			ClientID:    "testrunner",
+			CreateIP:    "192.168.1.2",
 		}
 		err := storer.CreateGrant(ctx, grant)
 		if err != nil {
@@ -301,6 +371,83 @@ func TestCreateDuplicateSourceGrant(t *testing.T) {
 		err = storer.CreateGrant(ctx, grant)
 		if !errors.Is(err, grants.ErrGrantSourceAlreadyUsed) {
 			t.Errorf("Expected error to be %v, %T returned %v\n", grants.ErrGrantSourceAlreadyUsed, storer, err)
+		}
+	})
+}
+
+func TestCreateAndRevokeGrant(t *testing.T) {
+	t.Parallel()
+
+	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
+		grant := grants.Grant{
+			ID:          uuidOrFail(t),
+			SourceType:  "manual",
+			SourceID:    "TestCreateAndRevokeGrant",
+			AncestorIDs: pqarrays.StringArray{uuidOrFail(t), uuidOrFail(t)},
+			UsedAt:      time.Now().Add(time.Hour).Round(time.Millisecond),
+			Scopes:      pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
+			ProfileID:   "tester",
+			AccountID:   "test123",
+			ClientID:    "testrunner",
+			CreateIP:    "192.168.1.2",
+		}
+		err := storer.CreateGrant(ctx, grant)
+		if err != nil {
+			t.Errorf("Unexpected error creating grant in %T: %+v\n", storer, err)
+		}
+
+		resp, err := storer.RevokeGrant(ctx, grant.ID)
+		if err != nil {
+			t.Errorf("Unexpected error exchanging grant in %T: %+v\n", storer, err)
+		}
+		expectation := grant
+		expectation.Revoked = true
+		if diff := cmp.Diff(expectation, resp); diff != "" {
+			t.Errorf("Unexpected diff (-wanted, +got): %s", diff)
+		}
+	})
+}
+
+func TestCreateAndRevokeUsedGrant(t *testing.T) {
+	t.Parallel()
+
+	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
+		grant := grants.Grant{
+			ID:          uuidOrFail(t),
+			SourceType:  "manual",
+			SourceID:    "TestCreateAndRevokeUsedGrant",
+			AncestorIDs: pqarrays.StringArray{uuidOrFail(t), uuidOrFail(t)},
+			UsedAt:      time.Now().Add(time.Hour).Round(time.Millisecond),
+			Scopes:      pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
+			ProfileID:   "tester",
+			AccountID:   "test123",
+			ClientID:    "testrunner",
+			CreateIP:    "192.168.1.2",
+		}
+		err := storer.CreateGrant(ctx, grant)
+		if err != nil {
+			t.Errorf("Unexpected error creating grant in %T: %+v\n", storer, err)
+		}
+
+		_, err = storer.ExchangeGrant(ctx, grants.GrantUse{Grant: grant.ID, IP: "1.2.3.4", Time: time.Now().Round(time.Millisecond)})
+		if err != nil {
+			t.Errorf("Unexpected error exchanging grant in %T: %+v\n", storer, err)
+		}
+
+		_, err = storer.RevokeGrant(ctx, grant.ID)
+		if !errors.Is(err, grants.ErrGrantAlreadyUsed) {
+			t.Errorf("Expected error to be %v, %T returned %v\n", grants.ErrGrantAlreadyUsed, storer, err)
+		}
+	})
+}
+
+func TestRevokeNonExistentGrant(t *testing.T) {
+	t.Parallel()
+
+	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
+		_, err := storer.RevokeGrant(ctx, uuidOrFail(t))
+		if !errors.Is(err, grants.ErrGrantNotFound) {
+			t.Errorf("Expected error to be %v, %T returned %v\n", grants.ErrGrantNotFound, storer, err)
 		}
 	})
 }

--- a/storer_test.go
+++ b/storer_test.go
@@ -154,15 +154,16 @@ func TestCreateAndGetRootGrant(t *testing.T) {
 
 	runTest(t, func(t *testing.T, storer grants.Storer, ctx context.Context) {
 		grant := grants.Grant{
-			ID:         uuidOrFail(t),
-			SourceType: "manual",
-			SourceID:   "TestCreateAndExchangeGrant",
-			UsedAt:     time.Now().Add(time.Hour).Round(time.Millisecond),
-			Scopes:     pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
-			ProfileID:  "tester",
-			AccountID:  "test123",
-			ClientID:   "testrunner",
-			CreateIP:   "192.168.1.2",
+			ID:          uuidOrFail(t),
+			SourceType:  "manual",
+			SourceID:    "TestCreateAndExchangeGrant",
+			AncestorIDs: []string{},
+			UsedAt:      time.Now().Add(time.Hour).Round(time.Millisecond),
+			Scopes:      pqarrays.StringArray{"https://scopes.impractical.co/test", "https://scopes.impractical.co/other/test"},
+			ProfileID:   "tester",
+			AccountID:   "test123",
+			ClientID:    "testrunner",
+			CreateIP:    "192.168.1.2",
 		}
 		err := storer.CreateGrant(ctx, grant)
 		if err != nil {

--- a/storers/postgres/grant.go
+++ b/storers/postgres/grant.go
@@ -11,20 +11,48 @@ import (
 // Grant is a representation of a Grant
 // suitable for storage in our Storer.
 type Grant struct {
-	ID          string
-	SourceType  string
-	SourceID    string
-	AncestorIDs pqarrays.StringArray
-	CreatedAt   time.Time
-	UsedAt      time.Time
-	Scopes      pqarrays.StringArray
-	AccountID   string
-	ProfileID   string
-	ClientID    string
-	CreateIP    string
-	UseIP       string
-	Used        bool
-	Revoked     bool
+	ID         string
+	SourceType string
+	SourceID   string
+	Ancestors  []GrantAncestor `sql_column:"-"`
+	CreatedAt  time.Time
+	UsedAt     time.Time
+	Scopes     pqarrays.StringArray
+	AccountID  string
+	ProfileID  string
+	ClientID   string
+	CreateIP   string
+	UseIP      string
+	Used       bool
+	Revoked    bool
+}
+
+func (g Grant) AncestorIDs() []string {
+	res := make([]string, 0, len(g.Ancestors))
+	for _, anc := range g.Ancestors {
+		res = append(res, anc.AncestorID)
+	}
+	return res
+}
+
+type GrantAncestor struct {
+	GrantID    string
+	AncestorID string
+}
+
+func (GrantAncestor) GetSQLTableName() string {
+	return "grants_ancestors"
+}
+
+func ancestorsFromIDs(grantID string, ancestorIDs []string) []GrantAncestor {
+	res := make([]GrantAncestor, 0, len(ancestorIDs))
+	for _, anc := range ancestorIDs {
+		res = append(res, GrantAncestor{
+			GrantID:    grantID,
+			AncestorID: anc,
+		})
+	}
+	return res
 }
 
 // GetSQLTableName allows us to use Grant with
@@ -38,7 +66,7 @@ func fromPostgres(grant Grant) grants.Grant {
 		ID:          grant.ID,
 		SourceType:  grant.SourceType,
 		SourceID:    grant.SourceID,
-		AncestorIDs: []string(grant.AncestorIDs),
+		AncestorIDs: grant.AncestorIDs(),
 		CreatedAt:   grant.CreatedAt,
 		UsedAt:      grant.UsedAt,
 		Scopes:      []string(grant.Scopes),
@@ -54,19 +82,19 @@ func fromPostgres(grant Grant) grants.Grant {
 
 func toPostgres(grant grants.Grant) Grant {
 	return Grant{
-		ID:          grant.ID,
-		SourceType:  grant.SourceType,
-		SourceID:    grant.SourceID,
-		AncestorIDs: pqarrays.StringArray(grant.AncestorIDs),
-		CreatedAt:   grant.CreatedAt,
-		UsedAt:      grant.UsedAt,
-		Scopes:      pqarrays.StringArray(grant.Scopes),
-		AccountID:   grant.AccountID,
-		ProfileID:   grant.ProfileID,
-		ClientID:    grant.ClientID,
-		CreateIP:    grant.CreateIP,
-		UseIP:       grant.UseIP,
-		Used:        grant.Used,
-		Revoked:     grant.Revoked,
+		ID:         grant.ID,
+		SourceType: grant.SourceType,
+		SourceID:   grant.SourceID,
+		Ancestors:  ancestorsFromIDs(grant.ID, grant.AncestorIDs),
+		CreatedAt:  grant.CreatedAt,
+		UsedAt:     grant.UsedAt,
+		Scopes:     pqarrays.StringArray(grant.Scopes),
+		AccountID:  grant.AccountID,
+		ProfileID:  grant.ProfileID,
+		ClientID:   grant.ClientID,
+		CreateIP:   grant.CreateIP,
+		UseIP:      grant.UseIP,
+		Used:       grant.Used,
+		Revoked:    grant.Revoked,
 	}
 }

--- a/storers/postgres/grant.go
+++ b/storers/postgres/grant.go
@@ -11,18 +11,20 @@ import (
 // Grant is a representation of a Grant
 // suitable for storage in our Storer.
 type Grant struct {
-	ID         string
-	SourceType string
-	SourceID   string
-	CreatedAt  time.Time
-	UsedAt     time.Time
-	Scopes     pqarrays.StringArray
-	AccountID  string
-	ProfileID  string
-	ClientID   string
-	CreateIP   string
-	UseIP      string
-	Used       bool
+	ID          string
+	SourceType  string
+	SourceID    string
+	AncestorIDs pqarrays.StringArray
+	CreatedAt   time.Time
+	UsedAt      time.Time
+	Scopes      pqarrays.StringArray
+	AccountID   string
+	ProfileID   string
+	ClientID    string
+	CreateIP    string
+	UseIP       string
+	Used        bool
+	Revoked     bool
 }
 
 // GetSQLTableName allows us to use Grant with
@@ -33,34 +35,38 @@ func (Grant) GetSQLTableName() string {
 
 func fromPostgres(grant Grant) grants.Grant {
 	return grants.Grant{
-		ID:         grant.ID,
-		SourceType: grant.SourceType,
-		SourceID:   grant.SourceID,
-		CreatedAt:  grant.CreatedAt,
-		UsedAt:     grant.UsedAt,
-		Scopes:     []string(grant.Scopes),
-		AccountID:  grant.AccountID,
-		ProfileID:  grant.ProfileID,
-		ClientID:   grant.ClientID,
-		CreateIP:   grant.CreateIP,
-		UseIP:      grant.UseIP,
-		Used:       grant.Used,
+		ID:          grant.ID,
+		SourceType:  grant.SourceType,
+		SourceID:    grant.SourceID,
+		AncestorIDs: []string(grant.AncestorIDs),
+		CreatedAt:   grant.CreatedAt,
+		UsedAt:      grant.UsedAt,
+		Scopes:      []string(grant.Scopes),
+		AccountID:   grant.AccountID,
+		ProfileID:   grant.ProfileID,
+		ClientID:    grant.ClientID,
+		CreateIP:    grant.CreateIP,
+		UseIP:       grant.UseIP,
+		Used:        grant.Used,
+		Revoked:     grant.Revoked,
 	}
 }
 
 func toPostgres(grant grants.Grant) Grant {
 	return Grant{
-		ID:         grant.ID,
-		SourceType: grant.SourceType,
-		SourceID:   grant.SourceID,
-		CreatedAt:  grant.CreatedAt,
-		UsedAt:     grant.UsedAt,
-		Scopes:     pqarrays.StringArray(grant.Scopes),
-		AccountID:  grant.AccountID,
-		ProfileID:  grant.ProfileID,
-		ClientID:   grant.ClientID,
-		CreateIP:   grant.CreateIP,
-		UseIP:      grant.UseIP,
-		Used:       grant.Used,
+		ID:          grant.ID,
+		SourceType:  grant.SourceType,
+		SourceID:    grant.SourceID,
+		AncestorIDs: pqarrays.StringArray(grant.AncestorIDs),
+		CreatedAt:   grant.CreatedAt,
+		UsedAt:      grant.UsedAt,
+		Scopes:      pqarrays.StringArray(grant.Scopes),
+		AccountID:   grant.AccountID,
+		ProfileID:   grant.ProfileID,
+		ClientID:    grant.ClientID,
+		CreateIP:    grant.CreateIP,
+		UseIP:       grant.UseIP,
+		Used:        grant.Used,
+		Revoked:     grant.Revoked,
 	}
 }

--- a/storers/postgres/sql/grants_20220905_0_ancestors_and_revoked.sql
+++ b/storers/postgres/sql/grants_20220905_0_ancestors_and_revoked.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+ALTER TABLE grants ADD COLUMN ancestor_ids VARCHAR[] NOT NULL DEFAULT array[]::varchar[],
+		   ADD COLUMN revoked BOOLEAN NOT NULL DEFAULT false;
+
+-- +migrate Down
+ALTER TABLE grants DROP COLUMN IF EXISTS ancestor_ids,
+		   DROP COLUMN IF EXISTS revoked;

--- a/storers/postgres/sql/grants_20220905_0_ancestors_and_revoked.sql
+++ b/storers/postgres/sql/grants_20220905_0_ancestors_and_revoked.sql
@@ -1,7 +1,14 @@
 -- +migrate Up
-ALTER TABLE grants ADD COLUMN ancestor_ids VARCHAR[] NOT NULL DEFAULT array[]::varchar[],
-		   ADD COLUMN revoked BOOLEAN NOT NULL DEFAULT false;
+CREATE TABLE grants_ancestors (
+	grant_id VARCHAR NOT NULL,
+	ancestor_id VARCHAR NOT NULL,
+
+	UNIQUE(grant_id, ancestor_id)
+);
+
+ALTER TABLE grants ADD COLUMN revoked BOOLEAN NOT NULL DEFAULT false;
 
 -- +migrate Down
-ALTER TABLE grants DROP COLUMN IF EXISTS ancestor_ids,
-		   DROP COLUMN IF EXISTS revoked;
+ALTER TABLE grants DROP COLUMN IF EXISTS revoked;
+
+DROP TABLE grants_ancestors;


### PR DESCRIPTION
If we add the concept of ancestry to Grants (so we can see when a Grant
is generated by another Grant and trace that chain back to the
beginning) and make Grants revocable, they can replace the entirety of
our tokens package. Refresh tokens will just be grants that are issued
to the client and exchanged for a new access token and new grant, then.

This allows us to avoid the awkward situation where a refresh token gets
exchanged for a grant and we need to mark both the grant and refresh
token as used. Without tightly coupling them, that setup has to allow
for an edge case where one gets marked as used but the other doesn't, if
the second to get marked as used returns an error. While it's possible
to sort of work around this (mark grant as used, then mark the refresh
token as used, because the refresh token can then be re-exchanged for a
new grant) it's weird and could lead to some confusion. By combining
them, we avoid the headache altogether and get to delete some code,
which is always nice.